### PR TITLE
Django Dashboard Argon - Disable SSL when required

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -129,7 +129,7 @@ STATICFILES_DIRS = (
 
 # Activate Django-Heroku.
 django_heroku.settings(locals())
-ssl_require = os.environ['ENV'] != 'development'
 ssl_require = os.environ['DATABASE_SSL'] != 'False'
+locals()['DATABASES']['default'] = dj_database_url.config(
     conn_max_age=django_heroku.MAX_CONN_AGE, ssl_require=ssl_require
 )

--- a/core/settings.py
+++ b/core/settings.py
@@ -8,6 +8,7 @@ import os
 from decouple import config
 from unipath import Path
 import django_heroku
+import dj_database_url
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR    = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -128,3 +129,7 @@ STATICFILES_DIRS = (
 
 # Activate Django-Heroku.
 django_heroku.settings(locals())
+ssl_require = os.environ['ENV'] != 'development'
+ssl_require = os.environ['DATABASE_SSL'] != 'False'
+    conn_max_age=django_heroku.MAX_CONN_AGE, ssl_require=ssl_require
+)


### PR DESCRIPTION
Basically some database like sqlite3 doesn't have the functionality to run on SSL and that's why I was getting when trying to run locally installation:
`TypeError: 'sslmode' is an invalid keyword argument for this function` error.
Or sometimes in development you want to run a connection just without SSL. This change will help with that. 
So in order to do that, add `DATABASE_SSL=False` to the `.env` file in the root of the project